### PR TITLE
Enable highlight colors for webdevicons

### DIFF
--- a/lua/deviconutil.lua
+++ b/lua/deviconutil.lua
@@ -7,7 +7,8 @@ local fn = vim.fn
 function M.get_icon(bufname)
   local loaded, webdev_icons = pcall(require, "nvim-web-devicons")
   if loaded then
-    return webdev_icons.get_icon(fn.fnamemodify(bufname, ":r"), fn.fnamemodify(bufname, ":e"), { default = true })
+    icon, hlgroup = webdev_icons.get_icon(fn.fnamemodify(bufname, ":r"), fn.fnamemodify(bufname, ":e"), { default = true })
+    return '%#' .. hlgroup .. '#' .. icon
   end
   local devicons_loaded = fn.exists("*WebDevIconsGetFileTypeSymbol") > 0
   return devicons_loaded and fn.WebDevIconsGetFileTypeSymbol(bufname) or ""

--- a/lua/deviconutil.lua
+++ b/lua/deviconutil.lua
@@ -9,7 +9,7 @@ function M.get_icon(bufname, is_selected)
   is_selected = is_selected ~= 0
   local loaded, webdev_icons = pcall(require, "nvim-web-devicons")
   if loaded then
-    icon, hlgroup = webdev_icons.get_icon(fn.fnamemodify(bufname, ":r"), fn.fnamemodify(bufname, ":e"), { default = true })
+    local icon, hlgroup = webdev_icons.get_icon(fn.fnamemodify(bufname, ":r"), fn.fnamemodify(bufname, ":e"), { default = true })
     hlgroup = M.get_hlgroup(hlgroup, is_selected)
     return '%#' .. hlgroup .. '#' .. icon
   end

--- a/lua/deviconutil.lua
+++ b/lua/deviconutil.lua
@@ -4,14 +4,35 @@
 local M = {}
 local fn = vim.fn
 
-function M.get_icon(bufname)
+
+function M.get_icon(bufname, is_selected)
+  is_selected = is_selected ~= 0
   local loaded, webdev_icons = pcall(require, "nvim-web-devicons")
   if loaded then
     icon, hlgroup = webdev_icons.get_icon(fn.fnamemodify(bufname, ":r"), fn.fnamemodify(bufname, ":e"), { default = true })
+    hlgroup = M.get_hlgroup(hlgroup, is_selected)
     return '%#' .. hlgroup .. '#' .. icon
   end
   local devicons_loaded = fn.exists("*WebDevIconsGetFileTypeSymbol") > 0
   return devicons_loaded and fn.WebDevIconsGetFileTypeSymbol(bufname) or ""
+end
+
+
+-- Construct/update a new icon-specific highlight group with the correct background for the tabline
+function M.get_hlgroup(hlgroup, is_selected)
+  local tab_hl, tab_attrs
+  if is_selected then
+    tab_hl = "TabLineSel" .. hlgroup
+    tab_attrs = vim.api.nvim_get_hl(0, { name = "TabLineSel" })
+  else
+    tab_hl = "TabLine" .. hlgroup
+    tab_attrs = vim.api.nvim_get_hl(0, { name = "TabLine" })
+  end
+
+  local custom_attrs = vim.api.nvim_get_hl(0, { name = hlgroup })
+  vim.api.nvim_set_hl(0, tab_hl, vim.tbl_extend("force", tab_attrs, custom_attrs))
+
+  return tab_hl
 end
 
 return M

--- a/plugin/mintabline.vim
+++ b/plugin/mintabline.vim
@@ -99,6 +99,7 @@ function! mintabline#main() abort
     let tab .= s:bufmodified(bufnr)
 
     let raw_tab = ' ' .. tabnr .. ' ' . s:tablabel(tabnr, bufnr, is_active_tab) . s:bufmodified(bufnr)
+    let raw_tab = substitute(raw_tab, "%#[a-zA-Z]\\+#", "", "g")
     call add(tabs, tab)
     call add(raw_tabs, raw_tab)
   endfor

--- a/plugin/mintabline.vim
+++ b/plugin/mintabline.vim
@@ -18,7 +18,7 @@ function! s:bufname(tabnr, bufnr, is_term, is_active_tab) abort
 
     let bufname = fnamemodify(bufname, ':t')
     let label = gettabvar(a:tabnr, "tab_label", "")
-    let bufname = (label == "" ? "" : (label . ":")) . bufname 
+    let bufname = (label == "" ? "" : (label . ":")) . bufname
 
     if !a:is_active_tab
           \ && exists('g:mintabline_tab_max_chars')
@@ -30,11 +30,11 @@ function! s:bufname(tabnr, bufnr, is_term, is_active_tab) abort
 endfunction
 
 " Returns the icon for the buffer
-function! s:icon(bufname, is_term) abort
+function! s:icon(bufname, is_term, is_active_tab) abort
     let icon = ''
 
     if has('nvim')
-      let icon = luaeval("require('deviconutil').get_icon(_A)", a:bufname)
+      let icon = luaeval("require('deviconutil').get_icon(_A[1],_A[2])", [a:bufname, a:is_active_tab])
     else
       if exists('*WebDevIconsGetFileTypeSymbol')
         let icon = WebDevIconsGetFileTypeSymbol(a:bufname)
@@ -70,7 +70,7 @@ endfunction
 function! s:tablabel(tabnr, bufnr, is_active_tab) abort
     let is_term = getbufvar(a:bufnr, '&buftype') == 'terminal'
     let original_bufname = bufname(a:bufnr)
-    let icon = s:icon(original_bufname, is_term)
+    let icon = s:icon(original_bufname, is_term, a:is_active_tab)
     let bufname = s:bufname(a:tabnr, a:bufnr, is_term, a:is_active_tab)
 
     return s:mergedlabel(bufname, icon)
@@ -113,7 +113,7 @@ function! mintabline#main() abort
   let active_tab_index = tabpagenr() - 1
 
   " Truncate tabs to fit window width
-  while window_width < strchars(join(raw_tabs, '')) 
+  while window_width < strchars(join(raw_tabs, ''))
     if iteration_count >= max_iterations
       break
     endif


### PR DESCRIPTION
Thanks for this great and simple plugin.  This PR colorizes the tab icons by including the highlight groups  from [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)

<img width="434" alt="image" src="https://github.com/user-attachments/assets/08692530-dc2a-41ae-9937-96a93f2b3123">
